### PR TITLE
Modified Quantity objects to use dictionaries

### DIFF
--- a/vunits/tests/test_convert.py
+++ b/vunits/tests/test_convert.py
@@ -236,7 +236,7 @@ class TestConvert(unittest.TestCase):
         # and units agreeing. Separating tests
         wavenumber_out = c.temp_to_wavenumber(temp, return_quantity=True)
         self.assertAlmostEqual(wavenumber_out.mag, wavenumber.mag)
-        self.assertTrue(wavenumber_out.units.equals(wavenumber.units))
+        self.assertEqual(wavenumber_out.units, wavenumber.units)
 
     def test_wavenumber_to_energy(self):
         wavenumber = Quantity.from_units(800., 'cm-1')
@@ -317,7 +317,7 @@ class TestConvert(unittest.TestCase):
         # and units agreeing. Separating tests
         temp_out = c.wavenumber_to_temp(wavenumber, return_quantity=True)
         self.assertAlmostEqual(temp_out.mag, temp.mag)
-        self.assertTrue(temp_out.units.equals(temp.units))
+        self.assertEqual(temp_out.units, temp.units)
 
     def test_debye_to_einstein(self):
         debye_temp = Quantity.from_units(200., 'K')

--- a/vunits/tests/test_quantity.py
+++ b/vunits/tests/test_quantity.py
@@ -266,8 +266,8 @@ class TestQuantityClass(unittest.TestCase):
         self.assertFalse(self.vel1._is_temp())
 
     def test_get_other_units(self):
-        self.assertTrue(self.vel2.units.equals(
-                self.vel1._get_other_units(self.vel2)))
+        self.assertEqual(self.vel2.units,
+                         self.vel1._get_other_units(self.vel2))
         self.assertIsNone(self.vel1._get_other_units(1))
 
     def test_call(self):


### PR DESCRIPTION
Previously, ``vunits.Quantity`` objects used ``pandas.DataFrames`` to keep track of units. However, this caused ``vunits.Quantity`` objects to initialize more slowly, which was problematic when creating the unit database (see issue #7).

To increase initialization speed, ``vunits.Quantity`` objects now use simpler dictionaries to keep track of units.